### PR TITLE
Resolving hardcoded directory in include

### DIFF
--- a/segbot_navigation/launch/move_base_eband.launch
+++ b/segbot_navigation/launch/move_base_eband.launch
@@ -18,8 +18,8 @@
     <rosparam file="$(find segbot_navigation)/config/$(arg config)/costmap_common_params.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find segbot_navigation)/config/$(arg config)/local_costmap_params.yaml" command="load" />
     <rosparam file="$(find segbot_navigation)/config/$(arg config)/global_costmap_params.yaml" command="load" />
-
-    <rosparam file="$(find segbot_navigation)/config/eband/eband_planner_params.yaml" command="load"/>
+    <rosparam file="$(find segbot_navigation)/config/$(arg config)/eband_planner_params.yaml" command="load"/>
+    
     <param name="base_local_planner" value="eband_local_planner/EBandPlannerROS" />
     <param name="base_global_planner" value="global_planner/GlobalPlanner" />
 


### PR DESCRIPTION
A recent commit changed most of the rosparam .yaml files to be found based on the robot version (segbotv2 or v3). 
One file, eband_planner_params.yaml had the old directory structure hardcoded in, preventing successful startup when running the bwi launch files on a segbot_v2.