### PR TITLE
segbot battery profiler

### DIFF
--- a/segbot_sensors/config/diagnostics_analyzer.yaml
+++ b/segbot_sensors/config/diagnostics_analyzer.yaml
@@ -7,7 +7,7 @@ analyzers:
     type: GenericAnalyzer
     path: Battery
     startswith: [
-        'battery_estimator',
+        'Remaining Battery Estimator',
         'voltage'
     ]
 #computers:

--- a/segbot_sensors/launch/diagnostic/diagnostics.launch
+++ b/segbot_sensors/launch/diagnostic/diagnostics.launch
@@ -3,7 +3,7 @@
   <!-- Set necessary parameters -->
   <param name="email_alert_outbound" type="string" value="bwi-operators@cs.utexas.edu" />
   <param name="email_alert_sender" type="string" value="utexas.bwi@gmail.com" />
-  <param name="weighted_average_const" type="double" value="0.1" />
+  <param name="weighted_average_const" type="double" value="0.05" />
   <param name="voltage_topic" type="string" value="/battery0" />
   <param name="voltage_threshold" type="double" value="10.0" />
   <param name="range_percent" type="double" value="1.0" />

--- a/segbot_sensors/package.xml
+++ b/segbot_sensors/package.xml
@@ -43,11 +43,14 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>openni_launch</exec_depend>
   <exec_depend>python-serial</exec_depend>
+  <exec_depend>python-scipy</exec_depend>
+  <exec_depend>python-numpy</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>rqt_robot_monitor</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>urg_node</exec_depend>
+
 
   <test_depend>roslaunch</test_depend>
 

--- a/segbot_sensors/src/segbot_sensors/battery_diagnostics.cpp
+++ b/segbot_sensors/src/segbot_sensors/battery_diagnostics.cpp
@@ -3,20 +3,23 @@
  * You must change the launch file parameters to adjust to other segbot models, if needed.
  *
  * This node sends emails and requires that the local smtp client is setup properly.
- * Please follow the instructions in  `segbot_sensors/sendmail_configure.sh`
+ * Please follow the instructions on the BWI Wiki.
  */
 
 #include "ros/ros.h"
 #include "ros/time.h"
-#include <vector>
 #include "std_msgs/Header.h"
 #include "std_msgs/Float32.h"
 #include "diagnostic_msgs/DiagnosticStatus.h"
 #include "diagnostic_msgs/DiagnosticArray.h"
 #include "diagnostic_msgs/KeyValue.h"
 #include "smart_battery_msgs/SmartBatteryStatus.h"
+#include <ros/package.h>
+#include <vector>
+#include <cmath>
 #include <stdio.h>
 #include <stdlib.h>
+#include <fstream>
 #include <unistd.h>
 #include <boost/thread.hpp>
 #include <boost/lexical_cast.hpp>
@@ -26,7 +29,6 @@ double alpha;
 
 void voltageCallback(const smart_battery_msgs::SmartBatteryStatus::ConstPtr& msg) {
   voltage = alpha * msg->voltage + (1.0 - alpha) * voltage;
-  //todo: add voltage profiler logic - write profile rates in /config
 }
 
 std::string getLocalHostname() {
@@ -36,6 +38,16 @@ std::string getLocalHostname() {
     return std::string(szHostName);
   }
   return error;
+}
+
+float getBatteryEstimate(double A, double K, double C, float voltage, double cutoffVoltage){
+  double max_life = std::log((cutoffVoltage - C) / -A) / K;
+  //Catch the case where the starting voltage is greater than the model accounts for.
+  //This can happen because the exponentially weighted voltage is initialized higher than the realized voltage.
+  if( voltage > C)
+     A *= -1;
+  double cur_life = std::log((voltage - C) / -A) / K;
+  return (max_life - cur_life) / 2; //Model is in 30-minute units. Divide by 2 to get intervals of 1 hour.
 }
 
 int sendMail(std::string outboundList, std::string sender) {
@@ -71,15 +83,15 @@ int main(int argc, char **argv) {
   std::string volt_topic;
   
   //parameters
-  n.param("weighted_average_const", alpha, .25);
-  n.param("voltage_threshold", threshold, 11.0);
-  n.param("range_percent", range, 0.2);
+  n.param("weighted_average_const", alpha, .05);
+  n.param("voltage_threshold", threshold, 10.9);
+  n.param("range_percent", range, 0.5);
   n.param("voltage_topic", volt_topic, (std::string) "/battery0");
-  voltage = threshold * 1.25; 				//initialize with a value that won't trigger mail service
+  voltage = threshold * 1.25;            //initialize with a value that won't trigger mail service
 
   ros::Publisher battery_life_pub = n.advertise<diagnostic_msgs::DiagnosticArray>("diagnostics", 10);
   ros::Subscriber voltage_sub = n.subscribe(volt_topic, 10, voltageCallback);
-  ros::Rate loop_rate(1); 				//1hz
+  ros::Rate loop_rate(1);                //1hz
   diagnostic_msgs::DiagnosticStatus voltages;
   diagnostic_msgs::DiagnosticStatus status;
   diagnostic_msgs::DiagnosticArray diagAr;
@@ -88,51 +100,73 @@ int main(int argc, char **argv) {
   voltages.hardware_id = "005";
   voltages.name = "voltage";
   voltages_val.value = voltage;
-  voltages_val.key = "Current voltage: ";
+  voltages_val.key = "segbot voltage: ";
   status.hardware_id = "005";
-  status.name = "battery_estimator"; 			//must match what the aggregator config file expects
-  status_val.key = "battery_value";
-  status_val.value = "183.0"; 				//dummy value
+  status.name = "Remaining Battery Estimator";       //must match what the aggregator config file expects
+  status_val.key = "Battery life remaining (hours)";
+  status_val.value = "183.0";            //dummy value
   std::ostringstream ss;
+  bool profileExists = false;
 
+  //Does there exist a battery profile? If so, acquire the parameters it defines
+  std::string path = ros::package::getPath("segbot_sensors");
+  path += "/config/battery_profile";
+  std::ifstream infile(path.c_str());
+  profileExists = infile.good();
+  double A, K, C, value = 0.0;
+  int count = 0;
   
+  while (infile >> value) {
+    switch (count) {
+      case (0) : A = value; break;
+      case (1) : K = value; break;
+      case (2) : C = value; break;
+      default: ROS_ERROR("ERROR. Profile has too many arguments. Abandoning battery estimation.\n");
+               profileExists = false;
+               break;
+    }
+    count += 1;
+  }
+
   while (ros::ok()) {
-    voltages_val.value = boost::lexical_cast<std::string>(voltage);
+    voltages_val.value = boost::lexical_cast<std::string>(voltage).substr(0,4);
+    voltages.message = voltages_val.value;
     diagAr.header.stamp = ros::Time::now();
     diagAr.header.frame_id = 1;
-
+    
+    if (profileExists)
+      status_val.value = boost::lexical_cast<std::string>(getBatteryEstimate(A, K, C, voltage, threshold+range)).substr(0,4);
+    
     if (voltage > range + threshold) {
-      status.message = "Battery in good health";
-      status.level = 0; 				// 0 = OK
+      status.message = status_val.value + " hours remain";
+      status.level = 0;                   // 0 = OK
       voltages.level = 0;
-      voltages.message = "Voltage level OK";
     } else if (voltage > threshold && voltage < (range + threshold)) {
       status.message = "Battery low, return to lab.";
-      status.level = 1; 				//1 = WARN
+      status.level = 1;                   //1 = WARN
       voltages.level = 1;
-      voltages.message = "Voltage dropping";
       if (!sentMail) {
         //To maintain steady diag readings, run sendmail on thread
+        sentMail = true;
         bool paramSuccess;
         std::string outbound;
         paramSuccess = n.getParam("email_alert_outbound", outbound);
         std::string send;
         paramSuccess &= n.getParam("email_alert_sender", send);
-        if(!paramSuccess) {
+        if (!paramSuccess) {
           std::cout << "Error reading send mail parameters. Check launchfile. Emails not sent." << std::endl;
         } else {
           boost::thread mailThread(sendMail, outbound, send);
         }
       }
-      sentMail = true;
-    } else if(!voltage) {
+    } else if (!voltage) {
       voltages.message = "No voltage data";
       voltages.level = 2;
       status.message = "Cannot extrapolate battery charge. No voltage data.";
       status.level = 2;
     } else {
       status.message = "Battery CRITICALLY low, or voltmeter data is inaccurate (or missing). Ensure the volt sensor is connected properly and its publisher relaying data.";
-      status.level = 2; 				//2 = CRITICAL
+      status.level = 2;                    //2 = CRITICAL
       voltages.level = 2;
       voltages.message = "ERROR: Ensure accurate volt readings!";
     }

--- a/segbot_sensors/src/segbot_sensors/battery_diagnostics.cpp
+++ b/segbot_sensors/src/segbot_sensors/battery_diagnostics.cpp
@@ -40,16 +40,20 @@ std::string getLocalHostname() {
   return error;
 }
 
-float getBatteryEstimate(double A, double K, double C, float voltage, double cutoffVoltage){
+/*
+ * Given the voltage and the parameters of the model, return the estimated time remaining in hours
+  */
+float getBatteryEstimate(double A, double K, double C, float voltage, double cutoffVoltage) {
   double max_life = std::log((cutoffVoltage - C) / -A) / K;
+  int negation = 1;
   //Catch the case where the starting voltage is greater than the model accounts for.
   //This can happen because the exponentially weighted voltage is initialized higher than the realized voltage.
-  if( voltage > C){
+  if( voltage > C) {
      A *= -1;
-     return (std::log((voltage - C) / -A) / K + max_life) / 2;
+     negation = -1;
   }
   double cur_life = std::log((voltage - C) / -A) / K;
-  return (max_life - cur_life) / 2; //Model is in 30-minute units. Divide by 2 to get intervals of 1 hour.
+  return (max_life - negation * cur_life) / 2; //Model is in 30-minute units. Divide by 2 to get intervals of 1 hour.
 }
 
 int sendMail(std::string outboundList, std::string sender) {
@@ -106,7 +110,7 @@ int main(int argc, char **argv) {
   status.hardware_id = "005";
   status.name = "Remaining Battery Estimator";       //must match what the aggregator config file expects
   status_val.key = "Battery life remaining (hours)";
-  status_val.value = "183.0";            //dummy value
+  status_val.value = "Unknown. Battery profile not set.";
   std::ostringstream ss;
   bool profileExists = false;
 

--- a/segbot_sensors/src/segbot_sensors/battery_diagnostics.cpp
+++ b/segbot_sensors/src/segbot_sensors/battery_diagnostics.cpp
@@ -44,8 +44,10 @@ float getBatteryEstimate(double A, double K, double C, float voltage, double cut
   double max_life = std::log((cutoffVoltage - C) / -A) / K;
   //Catch the case where the starting voltage is greater than the model accounts for.
   //This can happen because the exponentially weighted voltage is initialized higher than the realized voltage.
-  if( voltage > C)
+  if( voltage > C){
      A *= -1;
+     return (std::log((voltage - C) / -A) / K + max_life) / 2;
+  }
   double cur_life = std::log((voltage - C) / -A) / K;
   return (max_life - cur_life) / 2; //Model is in 30-minute units. Divide by 2 to get intervals of 1 hour.
 }
@@ -138,7 +140,7 @@ int main(int argc, char **argv) {
       status_val.value = boost::lexical_cast<std::string>(getBatteryEstimate(A, K, C, voltage, threshold+range)).substr(0,4);
     
     if (voltage > range + threshold) {
-      status.message = status_val.value + " hours remain";
+      status.message = status_val.value + " hours ";
       status.level = 0;                   // 0 = OK
       voltages.level = 0;
     } else if (voltage > threshold && voltage < (range + threshold)) {

--- a/segbot_sensors/src/segbot_sensors/battery_profiler.py
+++ b/segbot_sensors/src/segbot_sensors/battery_profiler.py
@@ -66,7 +66,12 @@ class battery_profiler:
     battery type. For instance, on a segbot_v3, this value should be around 71.5
     """
     def get_time_estimate(self, A, K, C, voltage):
-        return numpy.log((eol_voltage - C) / -A) / K - numpy.log((voltage - C) / -A) / K
+        max_life = numpy.log((eol_voltage - C) / -A) / K 
+	if voltage > C:
+		A = -A
+		return (numpy.log((voltage - C) / -A) / K + max_life)
+	cur_life = numpy.log((voltage - C) / -A) / K
+	return max_life - cur_life
 
     def writeModelToFile(self, A, K, C):
         print "Opening the file at {}...".format(self.model_filename)
@@ -118,7 +123,7 @@ class battery_profiler:
         print 'Model: -{} * exp({}x) + {}\n'.format(A, K, C)
         self.writeModelToFile(A, K, C)
 
-        print 'Time est for 11.5V: {} * 30 minutes'.format(self.get_time_estimate(A,K,C, 11.5))
+        print 'Time est for 12.5V: {} * 30 minutes'.format(self.get_time_estimate(A,K,C, 12.5))
 
         pyplot.plot(numpy.asarray(self.time_values), fit_y, "r--", label="Exponential Model")
         pyplot.show()

--- a/segbot_sensors/src/segbot_sensors/battery_profiler.py
+++ b/segbot_sensors/src/segbot_sensors/battery_profiler.py
@@ -68,13 +68,12 @@ class battery_profiler:
     def get_time_estimate(self, A, K, C, voltage):
         return numpy.log((eol_voltage - C) / -A) / K - numpy.log((voltage - C) / -A) / K
 
-    def writeModelToFile(self, A, K, C, tot_time):
+    def writeModelToFile(self, A, K, C):
         print "Opening the file at {}...".format(self.model_filename)
         target = open(self.model_filename, 'w')
         target.write(str(A)+'\n')
         target.write(str(K)+'\n')
         target.write(str(C)+'\n')
-        target.write(str(tot_time)+'\n')
         target.close()
         print "Model written to configuration file successfully."
 
@@ -117,7 +116,7 @@ class battery_profiler:
         A, K, C = fit_exp_nonlinear(numpy.asarray(self.time_values), numpy.asarray(self.voltage_values))
         fit_y = model_func(numpy.asarray(self.time_values), A, K, C)
         print 'Model: -{} * exp({}x) + {}\n'.format(A, K, C)
-        self.writeModelToFile(A, K, C, total_time)
+        self.writeModelToFile(A, K, C)
 
         print 'Time est for 11.5V: {} * 30 minutes'.format(self.get_time_estimate(A,K,C, 11.5))
 

--- a/segbot_sensors/src/segbot_sensors/battery_profiler.py
+++ b/segbot_sensors/src/segbot_sensors/battery_profiler.py
@@ -23,11 +23,10 @@ Currently, this
             plots the voltage data as well as the fitted model.
             writes the model to file for time-remaining estimation (handled elsewhere)
 
-TODO:
-    Make choosing bag file dynamic and consistent.
+Possible improvements:
     Have ways of merging multple runs into one model, or an existing model and an additional run
-    Make topic names, etc that are assumed rosparams?
-    Change from half hours to hours, without breaking fitting function
+    Change from half hours to hours, without breaking fitting function.
+        (note this would also requires changes to the battery diagnostics node)
 
 Author: Maxwell J Svetlik
 """
@@ -122,8 +121,6 @@ class battery_profiler:
         fit_y = model_func(numpy.asarray(self.time_values), A, K, C)
         print 'Model: -{} * exp({}x) + {}\n'.format(A, K, C)
         self.writeModelToFile(A, K, C)
-
-        print 'Time est for 12.5V: {} * 30 minutes'.format(self.get_time_estimate(A,K,C, 12.5))
 
         pyplot.plot(numpy.asarray(self.time_values), fit_y, "r--", label="Exponential Model")
         pyplot.show()

--- a/segbot_sensors/src/segbot_sensors/battery_profiler.py
+++ b/segbot_sensors/src/segbot_sensors/battery_profiler.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+import rospy
+import roslib
+import sys
+import rospy
+import rosbag
+import numpy
+import scipy.optimize
+import rospkg
+import socket
+
+from matplotlib import pyplot
+from scipy.optimize import curve_fit
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from std_msgs.msg import Header
+from rospy.numpy_msg import numpy_msg
+
+"""
+This program is a diagnostic tool for interpreting offline voltage data from the Segbot fleet.
+In particular, the program reads in a .bag file, and extracts voltage data published on the /diagnostics topic.
+
+Currently, this 
+            plots the voltage data as well as the fitted model.
+            writes the model to file for time-remaining estimation (handled elsewhere)
+
+TODO:
+    Make choosing bag file dynamic and consistent.
+    Have ways of merging multple runs into one model, or an existing model and an additional run
+    Make topic names, etc that are assumed rosparams?
+    Change from half hours to hours, without breaking fitting function
+
+Author: Maxwell J Svetlik
+"""
+
+sliding_window = 1
+half_hour_conversion = 1800
+eol_voltage = 10.75
+
+def model_func(t, A, K, C):
+    return -A * numpy.exp(K * t) + C
+
+def fit_exp_nonlinear(t, y):
+    opt_parms, parm_cov = scipy.optimize.curve_fit(model_func, t, y, maxfev=1000)
+    A, K, C = opt_parms
+    return A, K, C
+
+class battery_profiler:
+
+    def __init__(self):
+        print 'STARTING BATTERY PROFILER'
+        self.voltage_values = []
+        self.time_values = []
+        self.time_base = -1
+        self.rospack = rospkg.RosPack()
+        self.model_filename = self.rospack.get_path('segbot_sensors') + "/config/battery_profile"
+
+    def mySmooth(self, data, window):
+        smoothed = numpy.zeros((len(data), 1))
+        for d in range(len(data)):
+            smoothed[d] = numpy.mean(data[max(0, d-window):d])
+        return smoothed
+
+    """
+    returns the time remaining based on the current voltage value, and the estimated time to reach 
+    the end of life voltage (eol_voltage). Note that this voltage may need to be changed based on the specific 
+    battery type. For instance, on a segbot_v3, this value should be around 71.5
+    """
+    def get_time_estimate(self, A, K, C, voltage):
+        return numpy.log((eol_voltage - C) / -A) / K - numpy.log((voltage - C) / -A) / K
+
+    def writeModelToFile(self, A, K, C, tot_time):
+        print "Opening the file at {}...".format(self.model_filename)
+        target = open(self.model_filename, 'w')
+        target.write(str(A)+'\n')
+        target.write(str(K)+'\n')
+        target.write(str(C)+'\n')
+        target.write(str(tot_time)+'\n')
+        target.close()
+        print "Model written to configuration file successfully."
+
+    def listener(self):
+        try:
+             bag = rosbag.Bag(sys.argv[1])
+        except IOError:
+             print 'Could not open bag file at ' + sys.argv[1]
+             sys.exit(-1)
+        topic, msg_arr, t = bag.read_messages(topics=['/diagnostics']).next()
+        self.time_base = msg_arr.header.stamp.to_sec()
+        print 'Base time: {}\n'.format(self.time_base)
+
+        for topic, msg_arr, t in bag.read_messages(topics=['/diagnostics']):
+            for msg in msg_arr.status:
+                if msg.name == 'voltage':
+                    self.voltage_values.append(float(msg.values[0].value))
+                    """
+                    Collect relative times, and convert into half-hours
+                    Note that this is necessary for the exp-fit function; minutes are too large, hours are too small 
+                    in terms of values that the fit function can handle.
+                    """
+                    self.time_values.append(float((msg_arr.header.stamp.to_sec() - self.time_base) / half_hour_conversion))
+        bag.close()
+
+        pyplot.plot(self.time_values, self.mySmooth(self.voltage_values, sliding_window), 'b', label="Voltage Data")
+        title = 'Segbot Voltage over Time on Active Use: {}'.format(socket.gethostname())
+        pyplot.legend(loc=4)
+        pyplot.title(title)
+        pyplot.xlabel('Time ( 30-min Increments)') 
+        pyplot.ylabel('Voltage')
+        pyplot.legend(loc='upper right')
+
+        total_time = self.time_values[len(self.time_values) - 1] - self.time_values[0]
+        print 'EXPERIMENT DATA'
+        print 'Total run time: {}'.format(total_time)
+        print 'Starting voltage: {}'.format(self.voltage_values[0])
+        print 'Ending voltage: {}'.format(self.voltage_values[len(self.voltage_values) - 1])
+
+        A, K, C = fit_exp_nonlinear(numpy.asarray(self.time_values), numpy.asarray(self.voltage_values))
+        fit_y = model_func(numpy.asarray(self.time_values), A, K, C)
+        print 'Model: -{} * exp({}x) + {}\n'.format(A, K, C)
+        self.writeModelToFile(A, K, C, total_time)
+
+        print 'Time est for 11.5V: {} * 30 minutes'.format(self.get_time_estimate(A,K,C, 11.5))
+
+        pyplot.plot(numpy.asarray(self.time_values), fit_y, "r--", label="Exponential Model")
+        pyplot.show()
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print 'Missing argument: path to bagfile. Exiting.'
+        sys.exit(-1)
+    battery_profiler = battery_profiler()
+    rospy.init_node('battery_profiler', anonymous=True)
+    battery_profiler.listener()


### PR DESCRIPTION
These changes include a method to build the 'profile' for a battery used by a segbot, irrespective of version. This profile is then used to publish a battery remaining estimate on the diagnostics topic.