### PR TITLE
Redundant goals now fixed

### DIFF
--- a/segbot_logical_translator/src/nodes/segbot_logical_navigator.cpp
+++ b/segbot_logical_translator/src/nodes/segbot_logical_navigator.cpp
@@ -324,11 +324,6 @@ void SegbotLogicalNavigator::senseState(std::vector<PlannerAtom>& observations, 
 
   for (size_t door = 0; door < num_doors; ++door) {
 
-    if ((doors_[door].approach_names[0] != getLocationString(location_idx)) &&
-        (doors_[door].approach_names[1] != getLocationString(location_idx))) {
-      // We can't sense the current door since we're not in a location that this door connects.
-      continue;
-    }
 
     PlannerAtom beside_door;
     beside_door.value.push_back(getDoorString(door));


### PR DESCRIPTION
segbot_logical_navigator was failing to update certain fluents due to an if statement excluding non-connecting doors. Removing this fixes the issue with redundant goals specified in bwi_common issue #90