### PR TITLE
fixing spinning robot bug

### DIFF
--- a/segbot_navigation/config/segbotv3/move_base_params.yaml
+++ b/segbot_navigation/config/segbotv3/move_base_params.yaml
@@ -1,7 +1,19 @@
 footprint: [[0.265, 0.285], [0.265, -0.285], [-0.265, -0.285], [-0.38, 0], [-0.265, 0.285]]
-#robot_radius: 0.30
+
 planner_frequency: 1.0
-recovery_behaviors: [{name: rotate_recovery, type: rotate_recovery/RotateRecovery}]
-# recovery_behaviors: [{name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery}, {name: rotate_recovery, type: rotate_recovery/RotateRecovery}]
-# conservative_reset_dist: 0.5
-clearing_radius: 0.0
+
+recovery_behaviors:
+  - name: 'conservative_reset'
+    type: 'clear_costmap_recovery/ClearCostmapRecovery'
+  - name: 'rotate_recovery'
+    type: 'rotate_recovery/RotateRecovery'
+  - name: 'aggressive_reset'
+    type: 'clear_costmap_recovery/ClearCostmapRecovery'
+
+conservative_reset:
+  reset_distance: 3.0
+  layer_names: ['obstacle_layer']
+
+aggressive_reset:
+  reset_distance: 0.0
+  layer_names: ['obstacle_layer']


### PR DESCRIPTION
I've cleaned up and updated the `move_base` parameters file to include `clear_costmap_recovery` behaviors (in addition to `rotate_recovery`).  These provide a backup method for removing dynamic obstacles that have been added to the global costmap.

I tested this on Leela the morning of 14 July, 2017, and this seems to resolve the "spinning robot" bug, although time will tell for sure. At the very least, this update doesn't seem to negatively impact existing behaviors.

Finally, it still remains a mystery to me as to why `move_base`'s `make_plan` service returns a non-empty *but invalid* plan to `move_base_interruptable_server` in these scenarios. This behavior is what caused this bug in the first place since it circumvents the costmap-clearing condition in `move_base_interruptable_server` that exists to handle these scenarios.