### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/segbot_sensors/src/segbot_sensors_filters.cpp
+++ b/segbot_sensors/src/segbot_sensors_filters.cpp
@@ -10,6 +10,6 @@
 
 #include "pluginlib/class_list_macros.h"
 
-PLUGINLIB_REGISTER_CLASS(segbot_sensors/SegbotFootprintFilter, segbot_sensors::SegbotFootprintFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_REGISTER_CLASS(segbot_sensors/NanToInfFilter, segbot_sensors::NanToInfFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_REGISTER_CLASS(segbot_sensors/AngleRangeFilter, segbot_sensors::AngleRangeFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(segbot_sensors::SegbotFootprintFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(segbot_sensors::NanToInfFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(segbot_sensors::AngleRangeFilter, filters::FilterBase<sensor_msgs::LaserScan>)

--- a/segbot_sensors/src/sonar/range_nodelet.cpp
+++ b/segbot_sensors/src/sonar/range_nodelet.cpp
@@ -69,6 +69,5 @@ namespace segbot_sensors
 // Register this plugin with pluginlib.  Names must match
 // segbot_sensors_plugins.xml.
 //
-// parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(segbot_sensors, RangeNodelet,
-                        segbot_sensors::RangeNodelet, nodelet::Nodelet);
+// parameters are: class type, base class type
+PLUGINLIB_EXPORT_CLASS(segbot_sensors::RangeNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions